### PR TITLE
🔧Fix: Added encoding attribute to avoid an error happened on Windows:

### DIFF
--- a/app.py
+++ b/app.py
@@ -391,7 +391,7 @@ class ConfigManager:
         current_dir = os.path.dirname(os.path.abspath(__file__))
         config_path = os.path.join(current_dir, 'config', f'{workflow_type}_config.yaml')
         try:
-            with open(config_path, 'r') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 config = yaml.safe_load(f)
             ConfigValidator.validate_config(config)
             return config


### PR DESCRIPTION
`ERROR - Error loading or validating configuration: 'charmap' codec can't decode byte 0x8f in position 15: character maps to <undefined>`